### PR TITLE
Update nwrfclib.rb

### DIFF
--- a/lib/nwrfc/nwrfclib.rb
+++ b/lib/nwrfc/nwrfclib.rb
@@ -409,7 +409,7 @@ module NWRFCLib
     [:submit_transaction, :RfcSubmitTransaction, [:pointer, :pointer], :int],
     [:utf8_to_sapuc, :RfcUTF8ToSAPUC, [:pointer, :uint, :pointer, :pointer, :pointer, :pointer], :int]
   ].each{|funcsig|
-    attach_function(funcsig[0], funcsig[1], funcsig[2], funcsig[3])
+    attach_function(funcsig[0], funcsig[1], funcsig[2], funcsig[3], :blocking => true)
   }
 
   # Take Hash of connection parameters and returns FFI pointer to an array


### PR DESCRIPTION
:blocking => true

This prevents the Global Interpreter Lock being taken by FFI and never returned e.g. when SXPG_COMMAND_EXECUTE runs a function that never returns!

Using this it is possible to run calls in `Thread.new` but _ensure_ the Connection object exists within the same thread or prepare to get segfaults. 
